### PR TITLE
Munge configuration token-file to token_file

### DIFF
--- a/lib/puppetdb/config.rb
+++ b/lib/puppetdb/config.rb
@@ -15,7 +15,14 @@ class PuppetDB::Config
   end
 
   def load_file(path)
-    File.open(path) { |f| JSON.parse(f.read, symbolize_names: true)[:puppetdb] }
+    loaded_conf = File.open(path) { |f| JSON.parse(f.read, symbolize_names: true)[:puppetdb] }
+
+    # Munge token-file into token_file for better readability in Ruby
+    if loaded_conf[:'token-file']
+      loaded_conf[:token_file] = loaded_conf.delete(:'token-file')
+    end
+
+    loaded_conf
   end
 
   def puppetlabs_root


### PR DESCRIPTION
The puppetdb.conf may specify a token-file entry, but we are using it as
:token_file in Ruby. So we need to convert any token-file entry that we find